### PR TITLE
Fix conflicting provider on android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     testCompile 'junit:junit:4.12'
     apt 'com.github.hotchemi:permissionsdispatcher-processor:2.1.3'
     compile project(':filepicker')
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:appcompat-v7:25.2.0'
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.github.hotchemi:permissionsdispatcher:2.1.3'
-    compile 'com.android.support:support-v4:24.0.0'
+    compile 'com.android.support:support-v4:25.2.0'
 }

--- a/app/src/main/java/vi/filepicker/CallerFragment.java
+++ b/app/src/main/java/vi/filepicker/CallerFragment.java
@@ -132,7 +132,7 @@ public class CallerFragment extends BaseFragment {
         if((docPaths.size()+photoPaths.size())==MAX_ATTACHMENT_COUNT)
             Toast.makeText(getActivity(), "Cannot select more than " + MAX_ATTACHMENT_COUNT + " items", Toast.LENGTH_SHORT).show();
         else
-            FilePickerBuilder.getInstance().setMaxCount(maxCount)
+            FilePickerBuilder.getInstance(getActivity()).setMaxCount(maxCount)
                     .setSelectedFiles(photoPaths)
                     .setActivityTheme(R.style.FilePickerTheme)
                     .pickPhoto(this);
@@ -144,7 +144,7 @@ public class CallerFragment extends BaseFragment {
         if((docPaths.size()+photoPaths.size())==MAX_ATTACHMENT_COUNT)
             Toast.makeText(getActivity(), "Cannot select more than " + MAX_ATTACHMENT_COUNT + " items", Toast.LENGTH_SHORT).show();
         else
-            FilePickerBuilder.getInstance().setMaxCount(maxCount)
+            FilePickerBuilder.getInstance(getActivity()).setMaxCount(maxCount)
                     .setSelectedFiles(docPaths)
                     .setActivityTheme(R.style.FilePickerTheme)
                     .pickFile(this);

--- a/app/src/main/java/vi/filepicker/MainActivity.java
+++ b/app/src/main/java/vi/filepicker/MainActivity.java
@@ -96,7 +96,7 @@ public class MainActivity extends AppCompatActivity {
         if((docPaths.size()+photoPaths.size())==MAX_ATTACHMENT_COUNT)
             Toast.makeText(this, "Cannot select more than " + MAX_ATTACHMENT_COUNT + " items", Toast.LENGTH_SHORT).show();
         else
-            FilePickerBuilder.getInstance().setMaxCount(maxCount)
+            FilePickerBuilder.getInstance(this).setMaxCount(maxCount)
                     .setSelectedFiles(photoPaths)
                     .setActivityTheme(R.style.FilePickerTheme)
                     .addVideoPicker()
@@ -114,7 +114,7 @@ public class MainActivity extends AppCompatActivity {
         if((docPaths.size()+photoPaths.size())==MAX_ATTACHMENT_COUNT)
             Toast.makeText(this, "Cannot select more than " + MAX_ATTACHMENT_COUNT + " items", Toast.LENGTH_SHORT).show();
         else
-            FilePickerBuilder.getInstance().setMaxCount(maxCount)
+            FilePickerBuilder.getInstance(this).setMaxCount(maxCount)
                     .setSelectedFiles(docPaths)
                     .setActivityTheme(R.style.FilePickerTheme)
                     .addFileSupport("ZIP",zips)

--- a/filepicker/build.gradle
+++ b/filepicker/build.gradle
@@ -24,9 +24,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:support-v4:25.0.1'
-    compile 'com.android.support:design:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
+    compile 'com.android.support:support-v4:25.2.0'
+    compile 'com.android.support:design:25.2.0'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     testCompile 'junit:junit:4.12'
 }

--- a/filepicker/src/main/AndroidManifest.xml
+++ b/filepicker/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="droidninja.filepicker.provider"
+            android:authorities="${applicationId}.droidninja.filepicker.provider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/filepicker/src/main/java/droidninja/filepicker/FilePickerActivity.java
+++ b/filepicker/src/main/java/droidninja/filepicker/FilePickerActivity.java
@@ -38,9 +38,9 @@ public class FilePickerActivity extends AppCompatActivity implements
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTheme(PickerManager.getInstance().getTheme());
+        setTheme(PickerManager.getInstance(this).getTheme());
         setContentView(R.layout.activity_file_picker);
-        if(!PickerManager.getInstance().isEnableOrientation())
+        if(!PickerManager.getInstance(this).isEnableOrientation())
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         initView();
     }
@@ -57,25 +57,25 @@ public class FilePickerActivity extends AppCompatActivity implements
             setToolbarTitle(0);
 
             if(type == FilePickerConst.MEDIA_PICKER)
-                PickerManager.getInstance().add(selectedPaths, FilePickerConst.FILE_TYPE_MEDIA);
+                PickerManager.getInstance(this).add(selectedPaths, FilePickerConst.FILE_TYPE_MEDIA);
             else
-                PickerManager.getInstance().add(selectedPaths, FilePickerConst.FILE_TYPE_DOCUMENT);
+                PickerManager.getInstance(this).add(selectedPaths, FilePickerConst.FILE_TYPE_DOCUMENT);
 
-            PickerManager.getInstance().setPickerManagerListener(this);
+            PickerManager.getInstance(this).setPickerManagerListener(this);
             openSpecificFragment(type, selectedPaths);
         }
     }
 
     private void openSpecificFragment(int type, ArrayList<String> selectedPaths) {
-        if (PickerManager.getInstance().getMaxCount() == 1)
+        if (PickerManager.getInstance(this).getMaxCount() == 1)
             selectedPaths.clear();
 
         if (type == FilePickerConst.MEDIA_PICKER) {
             MediaPickerFragment photoFragment = MediaPickerFragment.newInstance();
             FragmentUtil.addFragment(this, R.id.container, photoFragment);
         } else {
-            if(PickerManager.getInstance().isDocSupport())
-                PickerManager.getInstance().addDocTypes();
+            if(PickerManager.getInstance(this).isDocSupport())
+                PickerManager.getInstance(this).addDocTypes();
 
             DocPickerFragment photoFragment = DocPickerFragment.newInstance(selectedPaths);
             FragmentUtil.addFragment(this, R.id.container, photoFragment);
@@ -85,8 +85,8 @@ public class FilePickerActivity extends AppCompatActivity implements
     private void setToolbarTitle(int count) {
         ActionBar actionBar = getSupportActionBar();
         if(actionBar!=null) {
-            if (PickerManager.getInstance().getMaxCount() > 1)
-                actionBar.setTitle(String.format(getString(R.string.attachments_title_text), count, PickerManager.getInstance().getMaxCount()));
+            if (PickerManager.getInstance(this).getMaxCount() > 1)
+                actionBar.setTitle(String.format(getString(R.string.attachments_title_text), count, PickerManager.getInstance(this).getMaxCount()));
             else {
                 if (type == FilePickerConst.MEDIA_PICKER)
                     actionBar.setTitle(R.string.select_photo_text);
@@ -109,9 +109,9 @@ public class FilePickerActivity extends AppCompatActivity implements
         int i = item.getItemId();
         if (i == R.id.action_done) {
             if (type == FilePickerConst.MEDIA_PICKER)
-                returnData(PickerManager.getInstance().getSelectedPhotos());
+                returnData(PickerManager.getInstance(this).getSelectedPhotos());
             else
-                returnData(PickerManager.getInstance().getSelectedFiles());
+                returnData(PickerManager.getInstance(this).getSelectedFiles());
 
             return true;
         } else if (i == android.R.id.home) {
@@ -147,9 +147,9 @@ public class FilePickerActivity extends AppCompatActivity implements
                 if(resultCode== Activity.RESULT_OK)
                 {
                     if (type == FilePickerConst.MEDIA_PICKER)
-                        returnData(PickerManager.getInstance().getSelectedPhotos());
+                        returnData(PickerManager.getInstance(this).getSelectedPhotos());
                     else
-                        returnData(PickerManager.getInstance().getSelectedFiles());
+                        returnData(PickerManager.getInstance(this).getSelectedFiles());
                 }
                 break;
         }

--- a/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.java
+++ b/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.java
@@ -1,10 +1,10 @@
 package droidninja.filepicker;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.DrawableRes;
-import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 
 import java.util.ArrayList;
@@ -17,26 +17,28 @@ import droidninja.filepicker.models.FileType;
 public class FilePickerBuilder {
 
     private final Bundle mPickerOptionsBundle;
+    private final Context context;
 
-    public FilePickerBuilder()
+    public FilePickerBuilder(Context context)
     {
         mPickerOptionsBundle = new Bundle();
+        this.context = context;
     }
 
-    public static FilePickerBuilder getInstance()
+    public static FilePickerBuilder getInstance(Context context)
     {
-        return new FilePickerBuilder();
+        return new FilePickerBuilder(context);
     }
 
     public FilePickerBuilder setMaxCount(int maxCount)
     {
-        PickerManager.getInstance().setMaxCount(maxCount);
+        PickerManager.getInstance(context).setMaxCount(maxCount);
         return this;
     }
 
     public FilePickerBuilder setActivityTheme(int theme)
     {
-        PickerManager.getInstance().setTheme(theme);
+        PickerManager.getInstance(context).setTheme(theme);
         return this;
     }
 
@@ -48,49 +50,49 @@ public class FilePickerBuilder {
 
     public FilePickerBuilder addVideoPicker()
     {
-        PickerManager.getInstance().setShowVideos(true);
+        PickerManager.getInstance(context).setShowVideos(true);
         return this;
     }
 
     public FilePickerBuilder showGifs(boolean status)
     {
-        PickerManager.getInstance().setShowGif(status);
+        PickerManager.getInstance(context).setShowGif(status);
         return this;
     }
 
     public FilePickerBuilder showFolderView(boolean status)
     {
-        PickerManager.getInstance().setShowFolderView(status);
+        PickerManager.getInstance(context).setShowFolderView(status);
         return this;
     }
 
     public FilePickerBuilder enableDocSupport(boolean status)
     {
-        PickerManager.getInstance().setDocSupport(status);
+        PickerManager.getInstance(context).setDocSupport(status);
         return this;
     }
 
     public FilePickerBuilder enableCameraSupport(boolean status)
     {
-        PickerManager.getInstance().setEnableCamera(status);
+        PickerManager.getInstance(context).setEnableCamera(status);
         return this;
     }
 
     public FilePickerBuilder enableOrientation(boolean status)
     {
-        PickerManager.getInstance().setEnableOrientation(status);
+        PickerManager.getInstance(context).setEnableOrientation(status);
         return this;
     }
 
     public FilePickerBuilder addFileSupport(String title, String[] extensions, @DrawableRes int drawable)
     {
-        PickerManager.getInstance().addFileType(new FileType(title,extensions,drawable));
+        PickerManager.getInstance(context).addFileType(new FileType(title,extensions,drawable));
         return this;
     }
 
     public FilePickerBuilder addFileSupport(String title, String[] extensions)
     {
-        PickerManager.getInstance().addFileType(new FileType(title,extensions,0));
+        PickerManager.getInstance(context).addFileType(new FileType(title,extensions,0));
         return this;
     }
 

--- a/filepicker/src/main/java/droidninja/filepicker/MediaDetailsActivity.java
+++ b/filepicker/src/main/java/droidninja/filepicker/MediaDetailsActivity.java
@@ -44,9 +44,9 @@ public class MediaDetailsActivity extends AppCompatActivity implements PickerMan
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTheme(PickerManager.getInstance().getTheme());
+        setTheme(PickerManager.getInstance(this).getTheme());
         setContentView(R.layout.activity_media_details);
-        if(!PickerManager.getInstance().isEnableOrientation())
+        if(!PickerManager.getInstance(this).isEnableOrientation())
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
         initView();
@@ -67,7 +67,7 @@ public class MediaDetailsActivity extends AppCompatActivity implements PickerMan
                     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
                     getSupportActionBar().setTitle(photoDirectory.getName());
                 }
-                PickerManager.getInstance().setPickerManagerListener(this);
+                PickerManager.getInstance(this).setPickerManagerListener(this);
             }
         }
     }
@@ -159,7 +159,7 @@ public class MediaDetailsActivity extends AppCompatActivity implements PickerMan
         }
         else
         {
-            photoGridAdapter = new PhotoGridAdapter(this, mGlideRequestManager, (ArrayList<Media>) medias,PickerManager.getInstance().getSelectedPhotos(),false);
+            photoGridAdapter = new PhotoGridAdapter(this, mGlideRequestManager, (ArrayList<Media>) medias,PickerManager.getInstance(this).getSelectedPhotos(),false);
             recyclerView.setAdapter(photoGridAdapter);
         }
 

--- a/filepicker/src/main/java/droidninja/filepicker/PickerManager.java
+++ b/filepicker/src/main/java/droidninja/filepicker/PickerManager.java
@@ -1,23 +1,31 @@
 package droidninja.filepicker;
 
+import android.content.Context;
+
 import java.util.ArrayList;
-import java.util.HashMap;
 
 import droidninja.filepicker.models.BaseFile;
 import droidninja.filepicker.models.FileType;
-import droidninja.filepicker.utils.Utils;
 
 /**
  * Created by droidNinja on 29/07/16.
  */
 public class PickerManager {
-    private static PickerManager ourInstance = new PickerManager();
+    private static PickerManager ourInstance;
     private int maxCount = FilePickerConst.DEFAULT_MAX_COUNT;
     private int currentCount;
     private PickerManagerListener pickerManagerListener;
     private ArrayList<String> alreadySelectedFiles;
+    private String providerAuthorities;
 
-    public static PickerManager getInstance() {
+    public static PickerManager getInstance(Context context) {
+        if (ourInstance == null) {
+            synchronized (PickerManager.class) {
+                if (ourInstance == null) {
+                    ourInstance = new PickerManager(context);
+                }
+            }
+        }
         return ourInstance;
     }
 
@@ -40,10 +48,11 @@ public class PickerManager {
 
     private boolean showFolderView = true;
 
-    private PickerManager() {
+    private PickerManager(Context context) {
         mediaFiles = new ArrayList<>();
         docFiles = new ArrayList<>();
         fileTypes = new ArrayList<>();
+        providerAuthorities = context.getApplicationContext().getPackageName() + ".droidninja.filepicker.provider";
     }
 
     public void setMaxCount(int count) {
@@ -210,5 +219,13 @@ public class PickerManager {
 
     public void setEnableOrientation(boolean enableOrientation) {
         this.enableOrientation = enableOrientation;
+    }
+
+    public void setProviderAuthorities(String providerAuthorities) {
+        this.providerAuthorities = providerAuthorities;
+    }
+
+    public String getProviderAuthorities() {
+        return providerAuthorities;
     }
 }

--- a/filepicker/src/main/java/droidninja/filepicker/adapters/FileListAdapter.java
+++ b/filepicker/src/main/java/droidninja/filepicker/adapters/FileListAdapter.java
@@ -49,8 +49,8 @@ public class FileListAdapter extends SelectableAdapter<FileListAdapter.FileViewH
         holder.itemView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if(PickerManager.getInstance().getMaxCount()==1)
-                    PickerManager.getInstance().add(document.getPath(), FilePickerConst.FILE_TYPE_DOCUMENT);
+                if(PickerManager.getInstance(context).getMaxCount()==1)
+                    PickerManager.getInstance(context).add(document.getPath(), FilePickerConst.FILE_TYPE_DOCUMENT);
                 else
                     onItemClicked(document,holder);
             }
@@ -83,19 +83,19 @@ public class FileListAdapter extends SelectableAdapter<FileListAdapter.FileViewH
 
     private void onItemClicked(Document document, FileViewHolder holder)
     {
-        if(holder.checkBox.isChecked() || PickerManager.getInstance().shouldAdd()) {
+        if(holder.checkBox.isChecked() || PickerManager.getInstance(context).shouldAdd()) {
             holder.checkBox.setChecked(!holder.checkBox.isChecked(), true);
         }
 
         if (holder.checkBox.isChecked())
         {
             holder.checkBox.setVisibility(View.VISIBLE);
-            PickerManager.getInstance().add(document.getPath(), FilePickerConst.FILE_TYPE_DOCUMENT);
+            PickerManager.getInstance(context).add(document.getPath(), FilePickerConst.FILE_TYPE_DOCUMENT);
         }
         else
         {
             holder.checkBox.setVisibility(View.GONE);
-            PickerManager.getInstance().remove(document.getPath(),FilePickerConst.FILE_TYPE_DOCUMENT);
+            PickerManager.getInstance(context).remove(document.getPath(),FilePickerConst.FILE_TYPE_DOCUMENT);
         }
     }
 

--- a/filepicker/src/main/java/droidninja/filepicker/adapters/PhotoGridAdapter.java
+++ b/filepicker/src/main/java/droidninja/filepicker/adapters/PhotoGridAdapter.java
@@ -80,10 +80,10 @@ public class PhotoGridAdapter extends SelectableAdapter<PhotoGridAdapter.PhotoVi
       holder.itemView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-          if(PickerManager.getInstance().getMaxCount()==1)
-            PickerManager.getInstance().add(media.getPath(), FilePickerConst.FILE_TYPE_MEDIA);
+          if(PickerManager.getInstance(context).getMaxCount()==1)
+            PickerManager.getInstance(context).add(media.getPath(), FilePickerConst.FILE_TYPE_MEDIA);
           else
-            if (holder.checkBox.isChecked() || PickerManager.getInstance().shouldAdd()) {
+            if (holder.checkBox.isChecked() || PickerManager.getInstance(context).shouldAdd()) {
             holder.checkBox.setChecked(!holder.checkBox.isChecked(), true);
           }
         }
@@ -95,7 +95,7 @@ public class PhotoGridAdapter extends SelectableAdapter<PhotoGridAdapter.PhotoVi
       holder.checkBox.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {
-          if(holder.checkBox.isChecked() || PickerManager.getInstance().shouldAdd()) {
+          if(holder.checkBox.isChecked() || PickerManager.getInstance(context).shouldAdd()) {
             holder.checkBox.setChecked(!holder.checkBox.isChecked(), true);
           }
         }
@@ -116,12 +116,12 @@ public class PhotoGridAdapter extends SelectableAdapter<PhotoGridAdapter.PhotoVi
           if (isChecked)
           {
             holder.checkBox.setVisibility(View.VISIBLE);
-            PickerManager.getInstance().add(media.getPath(), FilePickerConst.FILE_TYPE_MEDIA);
+            PickerManager.getInstance(context).add(media.getPath(), FilePickerConst.FILE_TYPE_MEDIA);
           }
           else
           {
             holder.checkBox.setVisibility(View.GONE);
-            PickerManager.getInstance().remove(media.getPath(),FilePickerConst.FILE_TYPE_MEDIA);
+            PickerManager.getInstance(context).remove(media.getPath(),FilePickerConst.FILE_TYPE_MEDIA);
           }
         }
       });

--- a/filepicker/src/main/java/droidninja/filepicker/cursors/DocScannerTask.java
+++ b/filepicker/src/main/java/droidninja/filepicker/cursors/DocScannerTask.java
@@ -82,7 +82,7 @@ public class DocScannerTask extends AsyncTask<Void,Void,List<Document>> {
 
             if(path!=null) {
 
-                FileType fileType = getFileType(PickerManager.getInstance().getFileTypes(),path);
+                FileType fileType = getFileType(PickerManager.getInstance(context).getFileTypes(),path);
                 if(fileType!=null && !(new File(path).isDirectory())) {
 
                     Document document = new Document(imageId, title, path);

--- a/filepicker/src/main/java/droidninja/filepicker/cursors/loadercallbacks/PhotoDirLoaderCallbacks.java
+++ b/filepicker/src/main/java/droidninja/filepicker/cursors/loadercallbacks/PhotoDirLoaderCallbacks.java
@@ -60,7 +60,7 @@ public class PhotoDirLoaderCallbacks implements LoaderManager.LoaderCallbacks<Cu
 
             if (!directories.contains(photoDirectory)) {
                 photoDirectory.setCoverPath(path);
-                if (PickerManager.getInstance().isShowGif() && path.toLowerCase().endsWith("gif"))
+                if (PickerManager.getInstance(context.get()).isShowGif() && path.toLowerCase().endsWith("gif"))
                     photoDirectory.addPhoto(imageId, fileName, path, mediaType);
                 else
                     photoDirectory.addPhoto(imageId, fileName, path, mediaType);

--- a/filepicker/src/main/java/droidninja/filepicker/fragments/DocFragment.java
+++ b/filepicker/src/main/java/droidninja/filepicker/fragments/DocFragment.java
@@ -109,7 +109,8 @@ public class DocFragment extends BaseFragment {
 
             FileListAdapter fileListAdapter = (FileListAdapter) recyclerView.getAdapter();
             if(fileListAdapter==null) {
-                fileListAdapter = new FileListAdapter(getActivity(), dirs, PickerManager.getInstance().getSelectedFiles());
+                fileListAdapter = new FileListAdapter(getActivity(), dirs, PickerManager
+                        .getInstance(getActivity()).getSelectedFiles());
 
                 recyclerView.setAdapter(fileListAdapter);
             }

--- a/filepicker/src/main/java/droidninja/filepicker/fragments/DocPickerFragment.java
+++ b/filepicker/src/main/java/droidninja/filepicker/fragments/DocPickerFragment.java
@@ -107,7 +107,7 @@ public class DocPickerFragment extends BaseFragment {
 
     private void setUpViewPager() {
         SectionsPagerAdapter adapter = new SectionsPagerAdapter(getChildFragmentManager());
-        ArrayList<FileType> supportedTypes = PickerManager.getInstance().getFileTypes();
+        ArrayList<FileType> supportedTypes = PickerManager.getInstance(getActivity()).getFileTypes();
         for (int index = 0; index < supportedTypes.size(); index++) {
             adapter.addFragment(DocFragment.newInstance(supportedTypes.get(index)),supportedTypes.get(index).title);
         }

--- a/filepicker/src/main/java/droidninja/filepicker/fragments/MediaDetailPickerFragment.java
+++ b/filepicker/src/main/java/droidninja/filepicker/fragments/MediaDetailPickerFragment.java
@@ -192,7 +192,9 @@ public class MediaDetailPickerFragment extends BaseFragment{
             }
             else
             {
-                photoGridAdapter = new PhotoGridAdapter(getActivity(), mGlideRequestManager, (ArrayList<Media>) medias, PickerManager.getInstance().getSelectedPhotos(),(fileType==FilePickerConst.MEDIA_TYPE_IMAGE) && PickerManager.getInstance().isEnableCamera());
+                photoGridAdapter = new PhotoGridAdapter(getActivity(), mGlideRequestManager, (ArrayList<Media>) medias,
+                        PickerManager.getInstance(getActivity()).getSelectedPhotos(),(fileType==FilePickerConst.MEDIA_TYPE_IMAGE)
+                        && PickerManager.getInstance(getActivity()).isEnableCamera());
                 recyclerView.setAdapter(photoGridAdapter);
                 photoGridAdapter.setCameraListener(new View.OnClickListener() {
                     @Override

--- a/filepicker/src/main/java/droidninja/filepicker/fragments/MediaFolderPickerFragment.java
+++ b/filepicker/src/main/java/droidninja/filepicker/fragments/MediaFolderPickerFragment.java
@@ -140,7 +140,7 @@ public class MediaFolderPickerFragment extends BaseFragment implements FolderGri
 
     private void getDataFromMedia() {
         Bundle mediaStoreArgs = new Bundle();
-        mediaStoreArgs.putBoolean(FilePickerConst.EXTRA_SHOW_GIF, PickerManager.getInstance().isShowGif());
+        mediaStoreArgs.putBoolean(FilePickerConst.EXTRA_SHOW_GIF, PickerManager.getInstance(getActivity()).isShowGif());
         mediaStoreArgs.putInt(FilePickerConst.EXTRA_FILE_TYPE, fileType);
 
         if(fileType==FilePickerConst.MEDIA_TYPE_IMAGE) {
@@ -209,7 +209,8 @@ public class MediaFolderPickerFragment extends BaseFragment implements FolderGri
             }
             else
             {
-                photoGridAdapter = new FolderGridAdapter(getActivity(), mGlideRequestManager, (ArrayList<PhotoDirectory>) dirs, null, (fileType==FilePickerConst.MEDIA_TYPE_IMAGE) && PickerManager.getInstance().isEnableCamera());
+                photoGridAdapter = new FolderGridAdapter(getActivity(), mGlideRequestManager, (ArrayList<PhotoDirectory>) dirs, null,
+                        (fileType==FilePickerConst.MEDIA_TYPE_IMAGE) && PickerManager.getInstance(getActivity()).isEnableCamera());
                 recyclerView.setAdapter(photoGridAdapter);
 
                 photoGridAdapter.setFolderGridAdapterListener(this);

--- a/filepicker/src/main/java/droidninja/filepicker/fragments/MediaPickerFragment.java
+++ b/filepicker/src/main/java/droidninja/filepicker/fragments/MediaPickerFragment.java
@@ -80,15 +80,15 @@ public class MediaPickerFragment extends BaseFragment{
 
         SectionsPagerAdapter adapter = new SectionsPagerAdapter(getChildFragmentManager());
 
-        if(PickerManager.getInstance().isShowFolderView())
+        if(PickerManager.getInstance(getActivity()).isShowFolderView())
             adapter.addFragment(MediaFolderPickerFragment.newInstance(FilePickerConst.MEDIA_TYPE_IMAGE), getString(R.string.images));
         else
             adapter.addFragment(MediaDetailPickerFragment.newInstance(FilePickerConst.MEDIA_TYPE_IMAGE), getString(R.string.images));
 
 
-        if(PickerManager.getInstance().showVideo())
+        if(PickerManager.getInstance(getActivity()).showVideo())
         {
-            if(PickerManager.getInstance().isShowFolderView())
+            if(PickerManager.getInstance(getActivity()).isShowFolderView())
                 adapter.addFragment(MediaFolderPickerFragment.newInstance(FilePickerConst.MEDIA_TYPE_VIDEO), getString(R.string.videos));
             else
                 adapter.addFragment(MediaDetailPickerFragment.newInstance(FilePickerConst.MEDIA_TYPE_VIDEO), getString(R.string.videos));

--- a/filepicker/src/main/java/droidninja/filepicker/utils/ImageCaptureManager.java
+++ b/filepicker/src/main/java/droidninja/filepicker/utils/ImageCaptureManager.java
@@ -7,7 +7,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
-import android.provider.Settings;
 import android.support.v4.content.FileProvider;
 import android.text.TextUtils;
 import android.util.Log;
@@ -15,9 +14,8 @@ import android.util.Log;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
+
+import droidninja.filepicker.PickerManager;
 
 public class ImageCaptureManager {
 
@@ -66,7 +64,7 @@ public class ImageCaptureManager {
         File newFile = createImageFile();
         takePictureIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         takePictureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        Uri photoURI = FileProvider.getUriForFile(context, "droidninja.filepicker.provider", newFile);
+        Uri photoURI = FileProvider.getUriForFile(context, PickerManager.getInstance(context).getProviderAuthorities(), newFile);
         takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
       } else {
         takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(createImageFile()));


### PR DESCRIPTION
android:authorities need to be unique across all apps installed on your android device.

Installing a second app with this library will fail as they'll both try and use the             droidninja.filepicker.provider

Using the package name + droidninja.filepicker.provider means this should be unique to app