### PR TITLE
Remove background colors from layouts

### DIFF
--- a/filepicker/src/main/res/layout/fragment_doc_picker.xml
+++ b/filepicker/src/main/res/layout/fragment_doc_picker.xml
@@ -9,7 +9,6 @@
         android:id="@+id/tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:tabBackground="@android:color/white"
         app:tabTextColor="@android:color/darker_gray"
         app:tabSelectedTextColor="@color/colorAccent"
         >

--- a/filepicker/src/main/res/layout/fragment_media_folder_picker.xml
+++ b/filepicker/src/main/res/layout/fragment_media_folder_picker.xml
@@ -8,7 +8,6 @@
         android:id="@+id/recyclerview"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        android:background="@android:color/white"
         />
 
     <TextView

--- a/filepicker/src/main/res/layout/fragment_media_picker.xml
+++ b/filepicker/src/main/res/layout/fragment_media_picker.xml
@@ -9,7 +9,6 @@
         android:id="@+id/tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:tabBackground="@android:color/white"
         app:tabTextColor="@android:color/darker_gray"
         app:tabSelectedTextColor="@color/colorAccent"
         app:tabMaxWidth="0dp"

--- a/filepicker/src/main/res/layout/fragment_photo_picker.xml
+++ b/filepicker/src/main/res/layout/fragment_photo_picker.xml
@@ -1,14 +1,12 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@android:color/white">
+    android:layout_height="match_parent">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        android:background="@android:color/white"
         />
 
     <TextView


### PR DESCRIPTION
Since the lib allows for a custom theme, background colors shouldn't be set. I'm using your library, and passing it a dark theme, but the background never changes because it is set in the layout files. 

There doesn't seem to be a workaround for this so I'm hoping you'll merge.

Library is awesome other than that!