### PR TITLE
Implement Glide v4 library and minimal changes to current usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 /build
 /captures
+/.idea

--- a/app/src/main/java/vi/filepicker/ImageAdapter.java
+++ b/app/src/main/java/vi/filepicker/ImageAdapter.java
@@ -11,6 +11,7 @@ import android.view.WindowManager;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.RequestOptions;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -53,11 +54,12 @@ public class ImageAdapter extends RecyclerView.Adapter<ImageAdapter.FileViewHold
     public void onBindViewHolder(FileViewHolder holder, int position) {
         String path = paths.get(position);
         Glide.with(context).load(new File(path))
-                .centerCrop()
-                .dontAnimate()
+                .apply(RequestOptions
+                        .centerCropTransform()
+                        .dontAnimate()
+                        .override(imageSize, imageSize)
+                        .placeholder(droidninja.filepicker.R.drawable.image_placeholder))
                 .thumbnail(0.5f)
-                .override(imageSize, imageSize)
-                .placeholder(droidninja.filepicker.R.drawable.image_placeholder)
                 .into(holder.imageView);
     }
 

--- a/filepicker/build.gradle
+++ b/filepicker/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: "com.jfrog.bintray"
+apply plugin: 'android-apt'
 
 version = "2.0.7"
 
@@ -27,7 +28,8 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:support-v4:25.3.1'
     compile 'com.android.support:design:25.3.1'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile 'com.github.bumptech.glide:glide:4.0.0-RC1'
+    apt 'com.github.bumptech.glide:compiler:4.0.0-RC1'
     testCompile 'junit:junit:4.12'
 }
 

--- a/filepicker/src/main/java/droidninja/filepicker/adapters/FolderGridAdapter.java
+++ b/filepicker/src/main/java/droidninja/filepicker/adapters/FolderGridAdapter.java
@@ -11,6 +11,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.bumptech.glide.RequestManager;
+import com.bumptech.glide.request.RequestOptions;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -67,11 +68,12 @@ public class FolderGridAdapter extends SelectableAdapter<FolderGridAdapter.Photo
 
       if(AndroidLifecycleUtils.canLoadImage(holder.imageView.getContext())) {
         glide.load(new File(photoDirectory.getCoverPath()))
-                .centerCrop()
-                .dontAnimate()
+                .apply(RequestOptions
+                        .centerCropTransform()
+                        .dontAnimate()
+                        .override(imageSize, imageSize)
+                        .placeholder(R.drawable.image_placeholder))
                 .thumbnail(0.5f)
-                .override(imageSize, imageSize)
-                .placeholder(R.drawable.image_placeholder)
                 .into(holder.imageView);
       }
 

--- a/filepicker/src/main/java/droidninja/filepicker/adapters/PhotoGridAdapter.java
+++ b/filepicker/src/main/java/droidninja/filepicker/adapters/PhotoGridAdapter.java
@@ -10,6 +10,8 @@ import android.view.WindowManager;
 import android.widget.ImageView;
 
 import com.bumptech.glide.RequestManager;
+import com.bumptech.glide.request.RequestOptions;
+
 import java.io.File;
 import java.util.ArrayList;
 
@@ -70,11 +72,12 @@ public class PhotoGridAdapter extends SelectableAdapter<PhotoGridAdapter.PhotoVi
 
       if(AndroidLifecycleUtils.canLoadImage(holder.imageView.getContext())) {
         glide.load(new File(media.getPath()))
-                .centerCrop()
-                .dontAnimate()
+                .apply(RequestOptions
+                        .centerCropTransform()
+                        .dontAnimate()
+                        .override(imageSize, imageSize)
+                        .placeholder(R.drawable.image_placeholder))
                 .thumbnail(0.5f)
-                .override(imageSize, imageSize)
-                .placeholder(R.drawable.image_placeholder)
                 .into(holder.imageView);
       }
 


### PR DESCRIPTION
I implemented minimal changes to the usage of the Glide library. I think it still needs an implementation of an AppGlideModule. But at least I believe this PR will not have errors when using the latest Glide v4