### PR TITLE
Add new option to sort documents by name

### DIFF
--- a/app/src/main/java/vi/filepicker/MainActivity.java
+++ b/app/src/main/java/vi/filepicker/MainActivity.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 
 import droidninja.filepicker.FilePickerBuilder;
 import droidninja.filepicker.FilePickerConst;
+import droidninja.filepicker.models.sort.SortingTypes;
 import droidninja.filepicker.utils.Orientation;
 import permissions.dispatcher.NeedsPermission;
 import permissions.dispatcher.RuntimePermissions;
@@ -113,7 +114,7 @@ public class MainActivity extends AppCompatActivity {
     @NeedsPermission({Manifest.permission.WRITE_EXTERNAL_STORAGE})
     public void onPickDoc() {
         String[] zips = {".zip",".rar"};
-        String[] pdfs = {".mp3"};
+        String[] pdfs = {".pdf"};
         int maxCount = MAX_ATTACHMENT_COUNT-photoPaths.size();
         if((docPaths.size()+photoPaths.size())==MAX_ATTACHMENT_COUNT)
             Toast.makeText(this, "Cannot select more than " + MAX_ATTACHMENT_COUNT + " items", Toast.LENGTH_SHORT).show();
@@ -124,6 +125,7 @@ public class MainActivity extends AppCompatActivity {
                     .addFileSupport("ZIP",zips)
             .addFileSupport("PDF",pdfs,R.drawable.pdf_blue)
             .enableDocSupport(false)
+            .sortDocumentsBy(SortingTypes.name)
             .withOrientation(Orientation.UNSPECIFIED)
                     .pickFile(this);
     }

--- a/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.java
+++ b/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.java
@@ -9,6 +9,7 @@ import android.support.v4.app.Fragment;
 import java.util.ArrayList;
 
 import droidninja.filepicker.models.FileType;
+import droidninja.filepicker.models.sort.SortingTypes;
 import droidninja.filepicker.utils.Orientation;
 
 /**
@@ -103,6 +104,12 @@ public class FilePickerBuilder {
     public FilePickerBuilder addFileSupport(String title, String[] extensions)
     {
         PickerManager.getInstance().addFileType(new FileType(title,extensions,0));
+        return this;
+    }
+
+    public FilePickerBuilder sortDocumentsBy(SortingTypes type)
+    {
+        PickerManager.getInstance().setSortingType(type);
         return this;
     }
 

--- a/filepicker/src/main/java/droidninja/filepicker/PickerManager.java
+++ b/filepicker/src/main/java/droidninja/filepicker/PickerManager.java
@@ -1,12 +1,11 @@
 package droidninja.filepicker;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 
 import droidninja.filepicker.models.BaseFile;
 import droidninja.filepicker.models.FileType;
+import droidninja.filepicker.models.sort.SortingTypes;
 import droidninja.filepicker.utils.Orientation;
-import droidninja.filepicker.utils.Utils;
 
 /**
  * Created by droidNinja on 29/07/16.
@@ -17,6 +16,7 @@ public class PickerManager {
     private int currentCount;
     private boolean showImages = true;
     private int cameraDrawable = R.drawable.ic_camera;
+    private SortingTypes sortingType = SortingTypes.none;
 
     public static PickerManager getInstance() {
         return ourInstance;
@@ -229,4 +229,13 @@ public class PickerManager {
     {
         return cameraDrawable;
     }
+
+    public SortingTypes getSortingType() {
+        return sortingType;
+    }
+
+    public void setSortingType(SortingTypes sortingType) {
+        this.sortingType = sortingType;
+    }
+
 }

--- a/filepicker/src/main/java/droidninja/filepicker/cursors/loadercallbacks/FileMapResultCallback.java
+++ b/filepicker/src/main/java/droidninja/filepicker/cursors/loadercallbacks/FileMapResultCallback.java
@@ -1,0 +1,16 @@
+package droidninja.filepicker.cursors.loadercallbacks;
+
+import java.util.List;
+import java.util.Map;
+
+import droidninja.filepicker.models.Document;
+import droidninja.filepicker.models.FileType;
+
+/**
+ * Created by gabriel on 10/2/17.
+ */
+
+public interface FileMapResultCallback {
+    void onResultCallback(Map<FileType, List<Document>> files);
+}
+

--- a/filepicker/src/main/java/droidninja/filepicker/models/FileType.java
+++ b/filepicker/src/main/java/droidninja/filepicker/models/FileType.java
@@ -49,6 +49,16 @@ public class FileType implements Parcelable{
     }
 
     @Override
+    public boolean equals(Object obj) {
+        return obj != null && obj instanceof FileType && ((FileType) obj).title.equals(title);
+    }
+
+    @Override
+    public int hashCode() {
+        return title.hashCode();
+    }
+
+    @Override
     public int describeContents() {
         return 0;
     }

--- a/filepicker/src/main/java/droidninja/filepicker/models/sort/NameComparator.java
+++ b/filepicker/src/main/java/droidninja/filepicker/models/sort/NameComparator.java
@@ -1,0 +1,19 @@
+package droidninja.filepicker.models.sort;
+
+import java.util.Comparator;
+
+import droidninja.filepicker.models.Document;
+
+/**
+ * Created by gabriel on 10/2/17.
+ */
+
+public class NameComparator implements Comparator<Document> {
+
+    protected NameComparator() { }
+
+    @Override
+    public int compare(Document o1, Document o2) {
+        return o1.getTitle().toLowerCase().compareTo(o2.getTitle().toLowerCase());
+    }
+}

--- a/filepicker/src/main/java/droidninja/filepicker/models/sort/SortingTypes.java
+++ b/filepicker/src/main/java/droidninja/filepicker/models/sort/SortingTypes.java
@@ -1,0 +1,23 @@
+package droidninja.filepicker.models.sort;
+
+import java.util.Comparator;
+
+import droidninja.filepicker.models.Document;
+
+/**
+ * Created by gabriel on 10/2/17.
+ */
+
+public enum SortingTypes {
+    name(new NameComparator()), none(null);
+
+    final private Comparator<Document> comparator;
+
+    SortingTypes(Comparator<Document> comparator) {
+        this.comparator = comparator;
+    }
+
+    public Comparator<Document> getComparator() {
+        return comparator;
+    }
+}

--- a/filepicker/src/main/java/droidninja/filepicker/utils/MediaStoreHelper.java
+++ b/filepicker/src/main/java/droidninja/filepicker/utils/MediaStoreHelper.java
@@ -3,11 +3,16 @@ package droidninja.filepicker.utils;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 
+import java.util.Comparator;
+import java.util.List;
+
 import droidninja.filepicker.FilePickerConst;
 import droidninja.filepicker.cursors.DocScannerTask;
+import droidninja.filepicker.cursors.loadercallbacks.FileMapResultCallback;
 import droidninja.filepicker.cursors.loadercallbacks.FileResultCallback;
 import droidninja.filepicker.cursors.loadercallbacks.PhotoDirLoaderCallbacks;
 import droidninja.filepicker.models.Document;
+import droidninja.filepicker.models.FileType;
 import droidninja.filepicker.models.PhotoDirectory;
 
 public class MediaStoreHelper {
@@ -26,8 +31,11 @@ public class MediaStoreHelper {
       activity.getSupportLoaderManager().initLoader(FilePickerConst.MEDIA_TYPE_VIDEO, args, new PhotoDirLoaderCallbacks(activity, resultCallback));
   }
 
-  public static void getDocs(FragmentActivity activity, FileResultCallback<Document> fileResultCallback)
+  public static void getDocs(FragmentActivity activity,
+                             List<FileType> fileTypes,
+                             Comparator<Document> comparator,
+                             FileMapResultCallback fileResultCallback)
   {
-    new DocScannerTask(activity,fileResultCallback).execute();
+    new DocScannerTask(activity, fileTypes, comparator, fileResultCallback).execute();
   }
 }


### PR DESCRIPTION
Add new method to `FilePickerBuilder: sortDocumentsBy()`. This function takes in a `SortingTypes` value that tells the picker how should documents be sorted when they are shown in the linear `RecyclerView`. `SortingTypes` is an enum that currently only has 2 values: "name" and "none". Each
value provides a `Comparator` object to be used for sorting. "none" is the default value and it provides a `null` comparator to avoid sorting. In the future more sorting types could be easily added by creating a new enum value with an appropriate comparator.

In `DocScannerTask`, instead of returning a list of documents as result, return a map whose keys are file types and values are lists of documents. Each list is sorted using the provided `Comparator` to avoid doing extra work in the main thread. For this matter, `DocScannerTask` now uses new callback interface `FileMapResultCallback` instead of `FileResultCallback`. 

Use correct pdf extension in sample app.

This option only works for documents, I thought about using it for photos and videos as well, but then I realized that it's much harder to notice that a grid of photos is sorted than a list of file names.