### PR TITLE
Build intent

### DIFF
--- a/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.kt
+++ b/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.kt
@@ -115,6 +115,7 @@ class FilePickerBuilder {
         start(context, FilePickerConst.REQUEST_CODE_DOC)
     }
 
+
     fun pickFile(context: Fragment) {
         mPickerOptionsBundle.putInt(FilePickerConst.EXTRA_PICKER_TYPE, FilePickerConst.DOC_PICKER)
         start(context, FilePickerConst.REQUEST_CODE_DOC)

--- a/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.kt
+++ b/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.kt
@@ -140,6 +140,13 @@ class FilePickerBuilder {
         start(context, requestCode)
     }
 
+    fun build(pickerType: Int, context: Activity): Intent {
+        val intent = Intent(context, FilePickerActivity::class.java)
+        mPickerOptionsBundle.putInt(FilePickerConst.EXTRA_PICKER_TYPE, pickerType)
+        intent.putExtras(mPickerOptionsBundle)
+        return intent
+    }
+
     private fun start(context: Activity, requestCode: Int) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (ContextCompat.checkSelfPermission(context, FilePickerConst.PERMISSIONS_FILE_PICKER) != PackageManager.PERMISSION_GRANTED) {

--- a/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.kt
+++ b/filepicker/src/main/java/droidninja/filepicker/FilePickerBuilder.kt
@@ -115,7 +115,6 @@ class FilePickerBuilder {
         start(context, FilePickerConst.REQUEST_CODE_DOC)
     }
 
-
     fun pickFile(context: Fragment) {
         mPickerOptionsBundle.putInt(FilePickerConst.EXTRA_PICKER_TYPE, FilePickerConst.DOC_PICKER)
         start(context, FilePickerConst.REQUEST_CODE_DOC)


### PR DESCRIPTION
 Add build function  to launch picker from activity to use new activityResult callback
 
 val intent = FilePickerBuilder.instance
                            .setMaxCount(1)
                            .setSelectedFiles(pickerSelectedPaths as java.util.ArrayList<Uri>)
                            .setActivityTitle(getString(R.string.file_picker_label))
                            .enableCameraSupport(true)
                            .setActivityTheme(R.style.FilePickerTheme)
                            .showFolderView(false)
                            .enableImagePicker(true)
                            .build(FilePickerConst.MEDIA_PICKER, this)
                            resultLauncher.launch(intent)

 val filePickerResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
        if (result.resultCode == Activity.RESULT_OK) {
            result.data?.getParcelableArrayListExtra<Uri>(FilePickerConst.KEY_SELECTED_MEDIA)
                    ?.let {
                        // TODO handle file.
                    }
        }
    }